### PR TITLE
Node-failure tolerance via spare-node over-allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,21 @@ python test_pyjob.py --fail 120 --checkpoint ./chkpt --niters 1000
   ```
 
 ## Example submission scripts
-- [qsub_multi_mpiexec.sc](./qsub_multi_mpiexec.sc)
-  submission script doing continual trials of mpiexec until success or timeout
+
+Start with `examples/crash_restart/`.
+
 - [examples/crash_restart/](./examples/crash_restart/)
   4-node job with a 50% reserve (6 nodes) that crashes one node on purpose and
-  restarts on a spare. Its README walks through converting an ordinary job
-  script into a fault-tolerant one.
+  restarts on a spare. Its README explains how to make an ordinary job script
+  fault tolerant, with sample output from a real run.
+- [qsub_multi_mpiexec.sc](./qsub_multi_mpiexec.sc)
+  the same restart loop without the crash injector. Use this one as a
+  production template.
+
+Both keep a pool of candidate nodes and retire only the nodes that actually
+failed, so one failure does not use up the whole reserve. The example adds a
+deliberate fault and writes its output outside the repository, which is why it
+is a test rather than a template.
 
 ### Spare-node pool across restarts
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,49 @@ This repository includes several scripts to help manage and monitor jobs. After 
 
 - `get_healthy_nodes.sh`: Selects a subset of healthy nodes from a larger allocation, writing them to a new nodefile. This is key to the restart mechanism.
   ```bash
-  get_healthy_nodes.sh NODEFILE NUM_NODES_TO_SELECT NEW_NODEFILE
+  get_healthy_nodes.sh NODEFILE NUM_NODES_TO_SELECT NEW_NODEFILE [EXCLUDE_FILE]
   ```
+  Alongside `NEW_NODEFILE`, three node lists are written:
+  - `NEW_NODEFILE.healthy`: all nodes that passed the health check
+  - `NEW_NODEFILE.unhealthy`: all nodes that failed the check, or were excluded
+  - `NEW_NODEFILE.free`: healthy nodes not selected for this run (spares)
+
+  The invariant is `healthy = selected + free`, so the remaining spare capacity
+  of an over-allocated job can be inspected at any point during the run.
+
+  The optional `EXCLUDE_FILE` lists nodes that must never be selected, which is
+  how a node that crashed an earlier trial is kept out of later ones.
+
+- `utils/overalloc.sh`: Computes how many nodes to request so that a job of
+  `JOBSIZE` nodes keeps a percentage of extra nodes as a spare pool for restarts.
+  ```bash
+  overalloc.sh JOBSIZE RESERVE_PERCENT
+  ```
+  `total = JOBSIZE + ceil(JOBSIZE * RESERVE_PERCENT / 100)`, and any non-zero
+  percentage reserves at least one spare node.
+
+  **This is a calculator, not an allocator.** PBS fixes the node count from the
+  `#PBS -l select=` directive before the job script runs, so no part of
+  checkpoint_restart can request additional nodes. The reserve must be included
+  in the submission by the user; the package then manages spares within the
+  allocation it is given. Run `overalloc.sh` before submitting and write the
+  result into the directive:
+  ```bash
+  #PBS -l select=6         # overalloc.sh 4 50 -> 6
+  export JOBSIZE=4
+  export RESERVE_PERCENT=50
+  ```
+  These three values are not derived from one another. Changing `JOBSIZE`
+  without changing `select=` yields a smaller reserve than intended. Both
+  submission scripts recompute the requirement at runtime and abort if the
+  allocation is short.
+  | JOBSIZE | reserve | request | spares |
+  |---------|---------|---------|--------|
+  | 4       | 50%     | 6       | 2      |
+  | 10      | 20%     | 12      | 2      |
+  | 16      | 25%     | 20      | 4      |
+  | 512     | 20%     | 615     | 103    |
+  | 10      | 0%      | 10      | 0      |
 
 - `utils/flush.sh`: A utility to clean up processes on allocated nodes, excluding the head node. This script is not installed via pip.
   ```bash
@@ -83,9 +124,94 @@ python test_pyjob.py --fail 120 --checkpoint ./chkpt --niters 1000
 ```
 
 
+- `node_usage_summary.sh`: Prints a high level node-usage report for a run:
+  which nodes ran work, when each entered and left service, how long each was
+  held, which crashed, and how much of the spare reserve was spent.
+  ```bash
+  node_usage_summary.sh [RUNDIR] [simple|full]    # RUNDIR defaults to $PWD
+  ```
+  Two levels, because a 1000 node job would otherwise bury the screen:
+  - `simple` (default): output size depends on the number of trials, not the
+    number of nodes. One line per trial, an outcome histogram, and a capped
+    list of crashed nodes. Measured at 31 lines for a 1000 node, 3 trial run
+    where `full` produced 3434.
+  - `full`: every trial and every node listed individually.
+
+  Counts are always exact; only the node *name* lists are capped. Raise the cap
+  with `NODE_SUMMARY_MAX_LIST=<n>`. The submission script prints `simple` to the
+  console and writes `full` to `node_usage_full.log` in the run directory, so
+  the detail is always kept.
+  Reads `node_usage.tsv`, a tab-separated ledger the submission script appends
+  to as nodes enter and leave service:
+  ```
+  trial <TAB> node <TAB> START|COMPLETED|STOPPED|CRASHED <TAB> timestamp <TAB> epoch
+  ```
+
 ## Example submission scripts
 - [qsub_multi_mpiexec.sc](./qsub_multi_mpiexec.sc)
   submission script doing continual trials of mpiexec until success or timeout
+- [examples/crash_restart/](./examples/crash_restart/)
+  4-node job with a 50% reserve (6 nodes) that crashes one node on purpose and
+  restarts on a spare. Its README walks through converting an ordinary job
+  script into a fault-tolerant one.
+
+### Spare-node pool across restarts
+
+The submission script keeps a `nodefile_pool` of candidate nodes, separate from
+the per-trial nodefile handed to `mpiexec`. `PBS_NODEFILE` must **not** be
+pointed at the per-trial subset when selecting nodes: doing so shrinks the
+candidate pool to the nodes already in use and makes the spares unreachable on
+later trials.
+
+After a failed trial, only the nodes that actually died are retired:
+
+```bash
+cat crashed_nodes pbs_nodefile$RUN.unhealthy | sort -u > retired_nodes$RUN
+get_healthy_nodes.sh nodefile_pool $JOBSIZE pbs_nodefile$NEXT crashed_nodes
+```
+
+Retiring every node the failed trial *used* would drain the pool too fast: a
+4-node trial out of 6 would leave only 2 usable nodes and the next trial could
+not start. Retiring just the failed node keeps the healthy ones in rotation.
+
+When fewer than `JOBSIZE` usable nodes remain, `get_healthy_nodes.sh` exits 100
+and the loop stops early rather than spending the remaining trials on an
+allocation that can no longer host the job.
+
+### Run directory layout
+
+A run writes its own artifacts into one self-contained directory:
+
+```
+<rundir>/
+  run.log                    combined log for the whole job
+  nodefile_all               the full PBS allocation
+  nodefile_pool              candidate nodes, shrinks as nodes are retired
+  crashed_nodes              nodes that died, excluded from later trials
+  pbs_nodefile<N>            nodes used by trial N
+  pbs_nodefile<N>.healthy    health lists for trial N
+  pbs_nodefile<N>.unhealthy
+  pbs_nodefile<N>.free
+  retired_nodes<N>           cumulative retired set after trial N
+  node_usage.tsv             per-node ledger, one row per node per event
+  node_usage_full.log        full per-node usage summary
+  latest                     checkpoint (iteration number)
+  output.log                 job output
+  check_hang.log             hang-detector log
+```
+
+The location of `<rundir>` depends on the submission script:
+
+| Script | Run directory |
+|--------|---------------|
+| `qsub_multi_mpiexec.sc` | `$PBS_O_WORKDIR`, the directory the job was submitted from |
+| `examples/crash_restart/qsub.sc` | `tests/03-multi-node/results/batch-<jobid>/`, overridable with `TEST_ROOT` |
+
+The example writes outside the repository so that a test run leaves no artifacts
+in the tree under test.
+
+`get_healthy_nodes.sh` and `flush.sh` use `/tmp/$USER/pbs/` for node-local
+scratch; only the run's own artifacts are written to `<rundir>`.
 
 ## System Monitoring
 - [system_monitoring/README.md](./system_monitoring/README.md)

--- a/examples/crash_restart/README.md
+++ b/examples/crash_restart/README.md
@@ -1,0 +1,419 @@
+# crash_restart
+
+Reference example for node-failure tolerance: over-allocate a node reserve, and
+on node failure substitute a spare and resume from the last checkpoint.
+
+Without fault tolerance, the loss of a single node terminates the entire job and
+all uncheckpointed work is discarded. This example demonstrates the alternative:
+
+```
+trial 1 : nodeA  nodeB  nodeC  nodeD          nodeB fails at iteration 10
+trial 2 : nodeA         nodeC  nodeD  nodeE   nodeE substituted from reserve
+          execution resumes at iteration 10 and runs to completion
+```
+
+## Comparison
+
+The same four-node job, run on a system where one node fails partway through.
+
+### Without checkpoint_restart
+
+```bash
+#PBS -l select=4
+
+mpiexec -np 48 --ppn 12 python my_app.py
+```
+
+```
+00:00  job starts on nodeA nodeB nodeC nodeD
+02:00  nodeB fails
+02:00  PBS terminates the job
+       - all four nodes released
+       - two hours of computation discarded
+       - the job must be resubmitted and requeued
+```
+
+### With checkpoint_restart
+
+```bash
+#PBS -l select=6                       # 4 + 50% reserve
+
+for RUN in $(seq 1 $MAX_TRIALS); do
+    get_healthy_nodes.sh nodefile_pool $JOBSIZE pbs_nodefile$RUN crashed_nodes || break
+    export PBS_NODEFILE=$PWD/pbs_nodefile$RUN
+    mpiexec --no-vni -np 48 --ppn 12 python my_app.py --checkpoint ckpt/
+    [ $? -eq 0 ] && break
+    flush.sh
+done
+```
+
+```
+00:00  trial 1 starts on nodeA nodeB nodeC nodeD; nodeE nodeF held in reserve
+        ...  checkpoints written throughout
+02:00  nodeB fails
+02:00  nodeB recorded in crashed_nodes and excluded from further selection
+02:01  trial 2 starts on nodeA nodeC nodeD nodeE
+       - resumes from the last checkpoint
+       - the job never leaves the queue
+       - nodeF remains in reserve for a subsequent failure
+```
+
+### Summary
+
+| | Without | With |
+|---|---|---|
+| Nodes requested | 4 | 6 (4 + 50% reserve) |
+| Application changes | none | must checkpoint and resume |
+| Job script changes | none | retry loop, node selection |
+| Outcome of one node failure | job terminates | continues on a spare |
+| Work lost | everything since job start | everything since last checkpoint |
+| Recovery | manual resubmission, requeued | automatic, within the same allocation |
+| Node-hours consumed | 4 nodes x 2 h, discarded | 6 nodes held; 2 h retained |
+| Failures tolerated | 0 | 2 (one per spare node) |
+
+The reserve is not free: 6 nodes are charged for the duration of the job whether
+or not the spares are used. The trade is that cost against the expected cost of
+losing the job, which grows with both run time and node count. At small scale
+and short walltime, resubmission may well be cheaper. At large node counts, or
+for runs long enough that a failure becomes probable, the reserve is the lower
+expected cost.
+
+## Application requirements
+
+The application must satisfy two conditions:
+
+1. It writes a checkpoint at a regular interval.
+2. On startup it detects an existing checkpoint and resumes from it.
+
+These are the only requirements. An application that cannot resume from a
+checkpoint will restart from the beginning on every trial, and node
+substitution provides no benefit.
+
+## Adapting an existing job script
+
+A conventional four-node submission:
+
+```bash
+#!/bin/bash
+#PBS -l select=4
+#PBS -l walltime=1:00:00
+#PBS -q capacity
+#PBS -A datascience
+#PBS -l filesystems=flare
+
+cd $PBS_O_WORKDIR
+mpiexec -np 48 --ppn 12 python my_app.py --checkpoint ckpt/
+```
+
+Five modifications are required.
+
+### 1. Request the node reserve
+
+**The reserve must be requested by the user. checkpoint_restart cannot obtain
+additional nodes.**
+
+PBS reads the `#PBS -l select=` directive before the first line of the script is
+executed, so no code in the job can enlarge its own allocation. The package
+operates entirely within the nodes PBS has already granted: it selects `JOBSIZE`
+of them for the application, holds the remainder in reserve, and substitutes
+from that reserve when a node fails. If the allocation contains no surplus
+nodes, there is nothing to substitute and a node failure ends the job.
+
+`utils/overalloc.sh` is a calculator, run before submission, that determines the
+value to place in the directive:
+
+```bash
+$ overalloc.sh 4 50     # 4 nodes, 50% reserve
+6
+$ overalloc.sh 512 20   # 512 nodes, 20% reserve
+615
+```
+
+The resulting figure is written into the job script by hand, together with the
+two variables that must agree with it:
+
+```bash
+#PBS -l select=6              # total nodes requested from PBS
+...
+export JOBSIZE=4              # nodes the application runs on
+export RESERVE_PERCENT=50     # must satisfy overalloc.sh 4 50 = 6
+```
+
+These three values are declared in two separate places and are not derived from
+one another. Raising `JOBSIZE` without also raising `select=` produces a job
+with a smaller reserve than intended, or none at all. The example script guards
+against this by recomputing the requirement at runtime and aborting when the
+allocation is insufficient:
+
+```bash
+NEED=$(overalloc.sh $JOBSIZE $RESERVE_PERCENT)
+if [ "$NALLOC" -lt "$NEED" ]; then
+    echo "FAIL: allocation of $NALLOC is smaller than the required $NEED"
+    exit 1
+fi
+```
+
+Reproducing this check in an adapted script is recommended; the failure it
+prevents is otherwise silent until a node is lost.
+
+Select the reserve percentage according to the observed failure rate of the
+target system. 20% is a reasonable starting point at large node counts. Jobs at
+small node counts require at least one full spare node to tolerate any
+failure.
+
+### 2. Configure the environment
+
+```bash
+source /flare/Aurora_deployment/AuroraGPT/soft/checkpoint_restart/conda.sh
+export PATH=$REPO_DIR/utils:$REPO_DIR/job_monitoring:$PATH
+```
+
+The `conda.sh` invocation is mandatory. Without it, `python` is not present on
+the compute nodes and every rank terminates with exit status 127. `module load
+frameworks` may be substituted if a newer Python is required.
+
+### 3. Enclose the run in a retry loop
+
+```bash
+cat $PBS_NODEFILE | uniq > nodefile_all
+cp nodefile_all nodefile_pool
+touch crashed_nodes
+
+JOBSIZE=4
+for RUN in $(seq 1 10); do
+    # Select JOBSIZE healthy nodes, excluding any that have already failed
+    get_healthy_nodes.sh nodefile_pool $JOBSIZE pbs_nodefile$RUN crashed_nodes || {
+        echo "insufficient healthy nodes remaining"; break
+    }
+    export PBS_NODEFILE=$PWD/pbs_nodefile$RUN
+
+    mpiexec --no-vni -np $((JOBSIZE*12)) --ppn 12 \
+        python my_app.py --checkpoint ckpt/
+    [ $? -eq 0 ] && break        # completed successfully
+
+    flush.sh                     # terminate residual processes before retrying
+done
+```
+
+`get_healthy_nodes.sh` writes three list files adjacent to the nodefile:
+
+| File | Contents |
+|------|----------|
+| `pbs_nodefile$RUN` | nodes selected for this trial |
+| `.healthy` | all nodes that passed the health check |
+| `.unhealthy` | nodes that failed the check or were listed in the exclude file |
+| `.free` | healthy nodes not selected for this trial (the remaining reserve) |
+
+### 4. Identify failed nodes
+
+The fourth argument to `get_healthy_nodes.sh` is an exclude file. Nodes listed
+in it are treated as unusable and are never selected, irrespective of whether
+they remain reachable.
+
+The mechanism for populating this file depends on the failure detection
+available to the application. Where the application can identify the failed
+node, append it under a lock, as multiple ranks may write concurrently:
+
+```bash
+flock -x crashed_nodes.lock -c "echo $BAD_NODE >> crashed_nodes"
+```
+
+Entries must use the same form as `$PBS_NODEFILE`, the fully qualified
+`.hsn.cm.aurora.alcf.anl.gov` name. The output of `hostname` is the short name
+and will not match; `hostname -f` returns a different domain (`.hostmgmt.`) and
+will also fail to match.
+
+Where the failed node cannot be identified, `get_healthy_nodes.sh` pings every
+node at the start of each trial and excludes those that are unreachable.
+
+### 5. Report node usage
+
+```bash
+node_usage_summary.sh "$RUNDIR" simple
+```
+
+Reports the nodes that executed work, the time each entered and left service,
+total time held per node, nodes lost to failure, and the proportion of the
+reserve consumed. The `full` argument produces the complete per-node table.
+At 1000 nodes `full` exceeds 3400 lines; `simple` is fixed size at
+approximately 30 lines and is recommended for console output.
+
+## Running this example
+
+```bash
+qsub examples/crash_restart/qsub.sc
+```
+
+The job allocates six nodes, runs a four-node workload, induces a failure on one
+node during trial 1, and verifies that execution completes on a substituted
+spare. Artifacts are written to `tests/03-multi-node/results/batch-<jobid>/`,
+which may be redirected with `TEST_ROOT`.
+
+Parameters are defined at the top of the script:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `JOBSIZE` | 4 | nodes used by the application |
+| `RESERVE_PERCENT` | 50 | additional nodes requested as reserve |
+| `MAX_TRIALS` | 10 | maximum number of restarts before abandoning the job |
+| `CRASH_ON_TRIAL` | 1 | trial in which the fault is injected |
+| `CRASH_AFTER` | 40 | seconds into the run before the fault is injected |
+
+## Sample output
+
+Abridged from job 8747861 on Aurora. Per-rank progress lines and the repeated
+per-rank crash messages are elided; everything else is verbatim.
+
+```
+==========================================================
+Run dir   : .../tests/03-multi-node/results/batch-8747861
+Allocated : 6 nodes
+JOBSIZE   : 4  (+50% reserve -> needs 6)
+==========================================================
+Will inject a crash on x4210c2s3b0n0 during trial 1
+
+---------- TRIAL 1 ----------
+Build a 4 nodes nodefile from nodefile_pool
+Total number of nodes checked: 6
+Number of nodes that are healthy: 6
+Number of nodes that are unhealthy: 0
+Number of nodes that are selected: 4
+Number of healthy nodes still free: 2
+Node lists: pbs_nodefile1.healthy pbs_nodefile1.unhealthy pbs_nodefile1.free
+trial 1 started at 2026-08-11 04:37:07
+running on:
+    [2026-08-11 04:37:07] x4216c7s0b0n0.hsn.cm.aurora.alcf.anl.gov
+    [2026-08-11 04:37:07] x4210c2s3b0n0.hsn.cm.aurora.alcf.anl.gov
+    [2026-08-11 04:37:07] x4300c2s4b0n0.hsn.cm.aurora.alcf.anl.gov
+    [2026-08-11 04:37:07] x4310c1s0b0n0.hsn.cm.aurora.alcf.anl.gov
+free pool : x4618c1s3b0n0.hsn... x4417c4s7b0n0.hsn...
+CRASH-INJECT: simulating node failure on x4210c2s3b0n0 (trial 1)
+x4210c2s3b0n0.hsn...: rank 21 exited with code 42
+x4210c2s3b0n0.hsn...: rank 12 died from signal 15
+trial 1 ended at 2026-08-11 04:37:19 (exit 143)
+Job exited with 143, will rerun
+retired so far: x4210c2s3b0n0.hsn.cm.aurora.alcf.anl.gov
+checkpoint at : 11
+
+---------- TRIAL 2 ----------
+Build a 4 nodes nodefile from nodefile_pool
+Total number of nodes checked: 6
+Number of nodes that are healthy: 5
+Number of nodes that are unhealthy: 1
+Number of nodes that are selected: 4
+Number of healthy nodes still free: 1
+trial 2 started at 2026-08-11 04:37:27
+running on:
+    [2026-08-11 04:37:27] x4216c7s0b0n0.hsn.cm.aurora.alcf.anl.gov
+    [2026-08-11 04:37:27] x4300c2s4b0n0.hsn.cm.aurora.alcf.anl.gov
+    [2026-08-11 04:37:27] x4310c1s0b0n0.hsn.cm.aurora.alcf.anl.gov
+    [2026-08-11 04:37:27] x4618c1s3b0n0.hsn.cm.aurora.alcf.anl.gov
+free pool : x4417c4s7b0n0.hsn.cm.aurora.alcf.anl.gov
+Reading checkpoint from 11
+11 iteration ...
+   ...
+29 iteration ...
+trial 2 ended at 2026-08-11 04:37:48 (exit 0)
+Job run successfully on trial 2
+
+RESULT: SUCCESS after 2 trial(s)
+==========================================================
+Trials used     : 2
+Crashed nodes   : x4210c2s3b0n0.hsn.cm.aurora.alcf.anl.gov
+Final checkpoint: 29
+```
+
+Three lines establish that substitution occurred rather than a plain retry:
+`Number of nodes that are unhealthy: 1` in trial 2 shows the failed node was
+excluded; `x4618c1s3b0n0` appears in the trial 2 node list but not trial 1,
+so a spare was drawn from the reserve; and `Reading checkpoint from 11`
+confirms the work resumed instead of restarting.
+
+The node-usage summary is printed automatically when the job ends:
+
+```
+==========================================================
+ NODE USAGE SUMMARY (simple)
+==========================================================
+Window        : 2026-08-11 04:37:07 -> 2026-08-11 04:37:48  (41s)
+Allocated     : 6 nodes
+Trials run    : 2
+Nodes used    : 5 of 6
+Node-time     : 2m 12s total across all nodes and trials
+
+--- Per trial ---
+TRIAL     NODES  START               END                 HELD
+1             4  2026-08-11 04:37:07 2026-08-11 04:37:19 12s  (1 crashed)
+2             4  2026-08-11 04:37:27 2026-08-11 04:37:48 21s
+
+--- Node outcomes ---
+    COMPLETED    4
+    CRASHED      1
+
+--- Spare capacity ---
+Nodes that ran work : 5 of 6 allocated
+Nodes lost to crash : 1
+Spares drawn in     : 1 (beyond the 4 that started trial 1)
+Unspent reserve     : 1
+Crashed nodes:
+    x4210c2s3b0n0.hsn.cm.aurora.alcf.anl.gov
+==========================================================
+```
+
+`simple` mode is fixed size irrespective of node count and is what appears on
+the console. `full` mode adds per-trial node listings and a per-node table, and
+is written to `node_usage_full.log`. At 1000 nodes the two are 31 and 3434 lines
+respectively.
+
+### Run directory contents
+
+```
+run.log              nodefile_all            node_usage.tsv
+output.log           nodefile_pool           node_usage_full.log
+check_hang.log       crashed_nodes           latest
+pbs_nodefile1        pbs_nodefile1.healthy   pbs_nodefile1.unhealthy
+pbs_nodefile1.free   retired_nodes1
+pbs_nodefile2        pbs_nodefile2.healthy   pbs_nodefile2.unhealthy
+pbs_nodefile2.free
+```
+
+## crash_node.sh
+
+A fault injector intended for testing only. It wraps the target command and
+exits with a non-zero status on one designated host, recording that host in
+`$CRASHED_NODES_FILE`:
+
+```bash
+mpiexec ... launcher.sh crash_node.sh python my_app.py
+```
+
+On all other hosts it executes the command unmodified and is therefore
+transparent.
+
+It is located in `examples/` rather than `utils/` and is deliberately not
+installed onto `$PATH`, as a utility whose function is to terminate running
+applications should not be readily invocable in a production environment.
+
+## Operational notes
+
+**Checkpoint interval relative to failure time.** If the failure occurs before
+the application has written its first checkpoint, the restart repeats all prior
+work. When testing, ensure `CRASH_AFTER` exceeds the checkpoint interval.
+
+**Exit status is not a reliable indicator of success.** A retry loop that
+exhausts all trials still exits 0, and `qstat -x` reports terminated jobs with
+`state=F`, identical to jobs that completed normally. Verify the run log.
+
+**Retire only the nodes that failed.** Retiring every node used by a failed
+trial exhausts the reserve prematurely: retiring all four nodes of a failed
+trial reduces a six-node pool to two, and the subsequent trial cannot start.
+
+**Select from the full pool on every trial.** Node selection must draw from
+`nodefile_all` less the retired nodes. Selecting from the preceding trial's
+subset causes the available pool to contract on each iteration.
+
+## References
+
+- `utils/README.md` — helper script documentation
+- `../../README.md` — checkpoint_restart package documentation
+- `../fail`, `../hang`, `../nan` — additional failure-mode examples

--- a/examples/crash_restart/crash_node.sh
+++ b/examples/crash_restart/crash_node.sh
@@ -19,13 +19,14 @@ HOST=$(hostname)
 HOST_SHORT=${HOST%%.*}
 CRASH_SHORT=${CRASH_NODE%%.*}
 
-if [[ -n "${CRASH_NODE:-}" && "$HOST_SHORT" == "$CRASH_SHORT" && "${RUN:-}" == "${CRASH_ON_TRIAL:-}" ]]; then
+if [[ -n "$CRASH_NODE" && "$HOST_SHORT" == "$CRASH_SHORT" && "$RUN" == "$CRASH_ON_TRIAL" ]]; then
     sleep ${CRASH_AFTER:-30}
     echo "CRASH-INJECT: simulating node failure on $HOST_SHORT (trial $RUN)" >&2
     # Record the nodefile spelling of the host, not `hostname`'s short form,
     # so get_healthy_nodes.sh can exclude it by exact string match.
+    # Leave the lock file in place. Deleting it can break the lock for a rank
+    # that is still using it, and duplicate lines here are harmless anyway.
     flock -x "$CRASHED_NODES_FILE.lock" -c "echo $CRASH_NODE >> $CRASHED_NODES_FILE"
-    rm -f "$CRASHED_NODES_FILE.lock" 2>/dev/null
     exit 42
 fi
 

--- a/examples/crash_restart/crash_node.sh
+++ b/examples/crash_restart/crash_node.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Crash injector for restart testing.
+#
+# Wraps the real command. If the host it runs on is named in $CRASH_NODE and
+# the current trial matches $CRASH_ON_TRIAL, the rank exits non-zero after
+# $CRASH_AFTER seconds instead of running the command. The hostname is appended
+# to $CRASHED_NODES_FILE so the submission script can retire exactly that node.
+#
+# Usage: crash_node.sh <command> [args...]
+#
+# Hostname matching: on Aurora `hostname` returns the short name
+# (x4602c6s7b0n0) while PBS_NODEFILE holds the high-speed-network FQDN
+# (x4602c6s7b0n0.hsn.cm.aurora.alcf.anl.gov). `hostname -f` is no help either:
+# it resolves to a *different* domain (.hostmgmt.cm.aurora.alcf.anl.gov).
+# Compare on the short name only, but record the node using the exact string
+# from the nodefile so the restart loop can match it against the pool.
+
+HOST=$(hostname)
+HOST_SHORT=${HOST%%.*}
+CRASH_SHORT=${CRASH_NODE%%.*}
+
+if [[ -n "${CRASH_NODE:-}" && "$HOST_SHORT" == "$CRASH_SHORT" && "${RUN:-}" == "${CRASH_ON_TRIAL:-}" ]]; then
+    sleep ${CRASH_AFTER:-30}
+    echo "CRASH-INJECT: simulating node failure on $HOST_SHORT (trial $RUN)" >&2
+    # Record the nodefile spelling of the host, not `hostname`'s short form,
+    # so get_healthy_nodes.sh can exclude it by exact string match.
+    flock -x "$CRASHED_NODES_FILE.lock" -c "echo $CRASH_NODE >> $CRASHED_NODES_FILE"
+    rm -f "$CRASHED_NODES_FILE.lock" 2>/dev/null
+    exit 42
+fi
+
+exec "$@"

--- a/examples/crash_restart/qsub.sc
+++ b/examples/crash_restart/qsub.sc
@@ -1,0 +1,211 @@
+#!/bin/bash
+#PBS -l walltime=1:00:00
+#PBS -q capacity
+#PBS -N crash_restart_4of6
+#PBS -l select=6
+#PBS -l filesystems=flare
+#PBS -A datascience
+
+# Artifacts (including PBS stdout/stderr) are collected under tests/, not here.
+
+# ---------------------------------------------------------------------------
+# Node-crash restart test.
+#
+#   JOBSIZE=4 with a 50% reserve -> overalloc.sh 4 50 -> select=6
+#
+# Trial 1 runs on 4 of the 6 nodes and one of them is crashed on purpose.
+# That node is retired and trial 2 restarts on a node pulled from the free
+# pool, resuming from the checkpoint, and runs to completion.
+#
+# All artifacts of a run (nodefiles, checkpoint, logs, scratch) are written
+# inside a single self-contained directory: runs/<jobid>/
+# Nothing is written to $HOME or /tmp.
+# ---------------------------------------------------------------------------
+
+MAX_TRIALS=5
+export JOBSIZE=4
+export RESERVE_PERCENT=50
+
+# REPO_DIR is the checkpoint_restart checkout, derived from this script's own
+# location (examples/crash_restart/qsub.sc) so the script works no matter which
+# directory it is submitted from.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+CRASH_DIR=$SCRIPT_DIR
+cd "${PBS_O_WORKDIR:-$SCRIPT_DIR}"
+
+# Same environment the other submission scripts use; without it `python` is
+# not on PATH on the compute nodes and every rank dies with exit 127.
+source /flare/Aurora_deployment/AuroraGPT/soft/checkpoint_restart/conda.sh
+export PATH=$REPO_DIR/utils:$REPO_DIR/job_monitoring:$REPO_DIR:$PATH
+
+IFS='.' read -ra ADDR <<< "$PBS_JOBID"
+export JOBID=$ADDR
+
+# Test artifacts stay out of the repo under test. Override with TEST_ROOT.
+TEST_ROOT=${TEST_ROOT:-$(dirname "$REPO_DIR")/tests}
+RUNDIR=$TEST_ROOT/03-multi-node/results/batch-${JOBID:-manual}
+rm -rf "$RUNDIR"
+mkdir -p "$RUNDIR"
+cd "$RUNDIR"
+
+cat $PBS_NODEFILE | uniq > nodefile_all
+NALLOC=$(cat nodefile_all | wc -l)
+NEED=$(overalloc.sh $JOBSIZE $RESERVE_PERCENT)
+
+{
+echo "=========================================================="
+echo "Run dir   : $RUNDIR"
+echo "Allocated : $NALLOC nodes"
+echo "JOBSIZE   : $JOBSIZE  (+${RESERVE_PERCENT}% reserve -> needs $NEED)"
+echo "Nodes     : $(tr '\n' ' ' < nodefile_all)"
+echo "=========================================================="
+} | tee -a run.log
+
+if [ "$NALLOC" -lt "$NEED" ]; then
+    echo "FAIL: allocation of $NALLOC is smaller than the required $NEED" | tee -a run.log
+    exit 1
+fi
+
+touch crashed_nodes
+NO_PROGRESS=0
+PREV_CKPT=""
+
+# The candidate pool is the full allocation; nodes are retired as they crash.
+cp nodefile_all nodefile_pool
+
+# Crash the SECOND node of the allocation, during trial 1 only.
+export CRASH_NODE=$(sed -n 2p nodefile_all)
+export CRASH_ON_TRIAL=1
+# Must exceed the time to the first checkpoint (~1s per iteration) so there is
+# real progress to resume from, but leave iterations remaining.
+export CRASH_AFTER=12
+export CRASHED_NODES_FILE=$RUNDIR/crashed_nodes
+echo "Will inject a crash on $CRASH_NODE during trial $CRASH_ON_TRIAL" | tee -a run.log
+
+echo "Started running job at `date`" | tee -a run.log
+
+for RUN in `seq 1 $MAX_TRIALS`
+do
+    export RUN
+    {
+    echo "---------- TRIAL $RUN ----------"
+    echo "pool: $(tr '\n' ' ' < nodefile_pool)"
+    } | tee -a run.log
+
+    # Draw JOBSIZE healthy nodes, never reusing a node that already crashed
+    get_healthy_nodes.sh nodefile_pool $JOBSIZE pbs_nodefile$RUN crashed_nodes 2>&1 | tee -a run.log
+    if [ ${PIPESTATUS[0]} -ne 0 ]; then
+        echo "Spare pool exhausted: fewer than $JOBSIZE usable nodes remain." | tee -a run.log
+        echo "RESULT: FAILED (out of spare nodes) after $((RUN-1)) trials" | tee -a run.log
+        break
+    fi
+
+    export PBS_NODEFILE=$RUNDIR/pbs_nodefile$RUN
+
+    # Record when each node entered service this trial. node_usage.tsv is the
+    # ledger the end-of-run summary reads.
+    TRIAL_START_EPOCH=$(date +%s)
+    TRIAL_START=$(date '+%Y-%m-%d %H:%M:%S')
+    while read -r NODE; do
+        printf '%s\t%s\t%s\t%s\t%s\n' "$RUN" "$NODE" "START" "$TRIAL_START" "$TRIAL_START_EPOCH" \
+            >> node_usage.tsv
+    done < pbs_nodefile$RUN
+
+    {
+    echo "trial $RUN started at $TRIAL_START"
+    echo "running on:"
+    while read -r NODE; do echo "    [$TRIAL_START] $NODE"; done < pbs_nodefile$RUN
+    echo "free pool : $(tr '\n' ' ' < pbs_nodefile$RUN.free)"
+    } | tee -a run.log
+
+    touch output.log
+    check_hang.py --timeout 300 --outputs output.log \
+        --kill-command "pkill -u $USER mpiexec" >> check_hang.log 2>&1 &
+    HANG_PID=$!
+
+    # crash_node.sh sits between the launcher and the payload so it can fail
+    # one specific host; every other rank runs test_pyjob.py normally.
+    mpiexec --no-vni -np $((JOBSIZE*12)) --ppn 12 \
+        launcher.sh $CRASH_DIR/crash_node.sh \
+        python $REPO_DIR/test_pyjob.py \
+            --compute 1 --niters 30 --checkpoint latest --save-interval 1 \
+            --output output.log 2>&1 | tee -a run.log
+
+    EXIT_CODE=${PIPESTATUS[0]}
+    kill $HANG_PID 2>/dev/null
+
+    # Close out this trial's node usage. Mark the nodes that crashed so the
+    # summary can distinguish "released cleanly" from "died".
+    TRIAL_END_EPOCH=$(date +%s)
+    TRIAL_END=$(date '+%Y-%m-%d %H:%M:%S')
+    while read -r NODE; do
+        if grep -qxF "$NODE" crashed_nodes 2>/dev/null; then STATE=CRASHED
+        elif [ $EXIT_CODE -eq 0 ]; then STATE=COMPLETED
+        else STATE=STOPPED; fi
+        printf '%s\t%s\t%s\t%s\t%s\n' "$RUN" "$NODE" "$STATE" "$TRIAL_END" "$TRIAL_END_EPOCH" \
+            >> node_usage.tsv
+    done < pbs_nodefile$RUN
+    echo "trial $RUN ended at $TRIAL_END (exit $EXIT_CODE)" | tee -a run.log
+
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "Job run successfully on trial $RUN" | tee -a run.log
+        echo "RESULT: SUCCESS after $RUN trial(s)" | tee -a run.log
+        break
+    fi
+
+    echo "Job exited with $EXIT_CODE, will rerun" | tee -a run.log
+
+    # A restart only helps if the failure was a node failure. If no node was
+    # recorded as crashed and no rank was even able to start (127 = command
+    # not found, i.e. a broken environment), retrying just burns the
+    # remaining trials on the same error.
+    if [ ! -s crashed_nodes ] && [ ! -s pbs_nodefile$RUN.unhealthy ]; then
+        NEW_CKPT=$(cat latest 2>/dev/null || echo "")
+        if [ "$NEW_CKPT" == "$PREV_CKPT" ]; then
+            NO_PROGRESS=$((NO_PROGRESS+1))
+        else
+            NO_PROGRESS=0
+        fi
+        if [ $NO_PROGRESS -ge 2 ]; then
+            echo "Two consecutive trials failed with no node failure and no" | tee -a run.log
+            echo "checkpoint progress: this is not a recoverable node fault." | tee -a run.log
+            echo "RESULT: ABORTED (non-recoverable) after $RUN trials" | tee -a run.log
+            break
+        fi
+    else
+        NO_PROGRESS=0
+    fi
+    PREV_CKPT=$(cat latest 2>/dev/null || echo "")
+
+    # Retire ONLY the nodes that actually died, plus any that failed the health
+    # check. Nodes that were merely in use stay in the pool -- retiring all of
+    # them would drain a 6 node pool after a single 4 node trial.
+    cat crashed_nodes pbs_nodefile$RUN.unhealthy 2>/dev/null | sort -u > retired_nodes$RUN
+    {
+    echo "retired so far: $(tr '\n' ' ' < retired_nodes$RUN)"
+    echo "checkpoint at : $(cat latest 2>/dev/null || echo none)"
+    } | tee -a run.log
+
+    PBS_NODEFILE=$RUNDIR/nodefile_all flush.sh >> run.log 2>&1
+    sleep 5
+    echo | tee -a run.log
+done
+
+{
+echo "Finished at `date`"
+echo "=========================================================="
+echo "Trials used     : $RUN"
+echo "Crashed nodes   : $(tr '\n' ' ' < crashed_nodes)"
+echo "Final checkpoint: $(cat latest 2>/dev/null || echo none)"
+echo "Output lines    : $([ -f output.log ] && wc -l < output.log || echo 0)"
+echo "Artifacts in    : $RUNDIR"
+echo "=========================================================="
+} | tee -a run.log
+
+# High level node usage. The console gets the fixed-size 'simple' report so a
+# large job cannot flood the screen; the full per-node breakdown is written to
+# node_usage_full.log alongside the other artifacts.
+node_usage_summary.sh "$RUNDIR" simple 2>&1 | tee -a run.log
+node_usage_summary.sh "$RUNDIR" full > node_usage_full.log 2>&1
+echo "Full per-node breakdown: $RUNDIR/node_usage_full.log" | tee -a run.log

--- a/qsub_multi_mpiexec.sc
+++ b/qsub_multi_mpiexec.sc
@@ -2,8 +2,13 @@
 #PBS -l walltime=0:20:00
 #PBS -q prod
 #PBS -N test_checkpoint_restart
-#PBS -l select=4
+#PBS -l select=5
+
 #PBS -A datascience
+
+# Run JOBSIZE nodes and keep RESERVE_PERCENT extra nodes as a spare pool.
+# Size the "select=" above with:  overalloc.sh $JOBSIZE $RESERVE_PERCENT
+# e.g. JOBSIZE=4, RESERVE_PERCENT=20 -> overalloc.sh 4 20 -> select=5
 
 MAX_TRIALS=10
 source /flare/Aurora_deployment/AuroraGPT/soft/checkpoint_restart/conda.sh
@@ -15,7 +20,26 @@ cd ${PBS_O_WORKDIR}
 
 cat $PBS_NODEFILE | uniq > nodefile_all
 
-export JOBSIZE=2
+export JOBSIZE=4
+export RESERVE_PERCENT=20
+
+# The pool of candidate nodes. Nodes are retired from this pool as they fail,
+# so each trial draws from what is still usable.
+cp nodefile_all nodefile_pool
+
+echo "Requested $(cat nodefile_all | wc -l) nodes for a $JOBSIZE node job (${RESERVE_PERCENT}% reserve)"
+
+# select= above and JOBSIZE/RESERVE_PERCENT here are set independently, so a
+# change to one can silently leave the job with a smaller reserve than intended.
+# Fail immediately rather than discovering it when a node is lost.
+NALLOC=$(cat nodefile_all | wc -l)
+NEED=$(overalloc.sh $JOBSIZE $RESERVE_PERCENT)
+if [ "$NALLOC" -lt "$NEED" ]; then
+    echo "FAIL: allocation of $NALLOC nodes is smaller than the $NEED required"
+    echo "      for JOBSIZE=$JOBSIZE with a ${RESERVE_PERCENT}% reserve."
+    echo "      Set '#PBS -l select=$NEED' or lower JOBSIZE/RESERVE_PERCENT."
+    exit 1
+fi
 
 rm -f check_hang.r$JOBID
 
@@ -23,24 +47,39 @@ echo "Started running job at `date`"
 
 for RUN in `seq 1 $MAX_TRIALS`
 do
-    # select a subset of nodes to run the job
-    get_healthy_nodes.sh $PBS_NODEFILE $JOBSIZE pbs_nodefile$RUN
+    # select a subset of nodes to run the job, drawing from the pool
+    get_healthy_nodes.sh nodefile_pool $JOBSIZE pbs_nodefile$RUN
+    if [ $? -ne 0 ]; then
+        echo "Spare pool exhausted: fewer than $JOBSIZE healthy nodes remain. Giving up after $((RUN-1)) trials."
+        break
+    fi
+
+    # NOTE: only the run itself sees the subset; the pool is left intact
+    # so the next trial can still reach the spare nodes.
     export PBS_NODEFILE=pbs_nodefile$RUN
 
     # constantly check the job and kill the job if it hangs for 300 seconds
     check_hang.py --timeout 300 --outputs $PBS_JOBNAME.o$JOBID:$PBS_JOBNAME.e$JOBID:output.log --kill-command "pkill -u $USER mpiexec" >> check_hang.r$JOBID &
 
     # run the actual job, in this case, the job will run for 200 seconds and fail (finished about 9 iterations each time)
-    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 10 --niters 100 --output output.log 
+    mpiexec -np $((JOBSIZE*12)) --ppn 12 launcher.sh python ./test_pyjob.py --compute 10 --niters 100 --output output.log
 
     EXIT_CODE=$?
     # Check the job status
     if [ $EXIT_CODE -ne 0 ]; then
-	echo "Job exited with $EXIT_CODE error code, will rerun"	
+	echo "Job exited with $EXIT_CODE error code, will rerun"
     else
         echo "Job run successfully"
         break
     fi
+
+    # Retire the nodes used by this failed trial, plus anything that failed the
+    # health check, so the next trial pulls fresh nodes from the spare pool.
+    cat pbs_nodefile$RUN pbs_nodefile$RUN.unhealthy 2>/dev/null | sort -u > retired_nodes$RUN
+    grep -vxF -f retired_nodes$RUN nodefile_pool > nodefile_pool.next
+    mv nodefile_pool.next nodefile_pool
+    echo "Spare pool after trial $RUN: $(cat nodefile_pool | wc -l) nodes remain"
+
     echo "Rerun the job at `date`; time of trials: $RUN"
     # clear up the nodes for rerun the job
     pkill check_hang.py

--- a/qsub_multi_mpiexec.sc
+++ b/qsub_multi_mpiexec.sc
@@ -11,7 +11,14 @@
 # e.g. JOBSIZE=4, RESERVE_PERCENT=20 -> overalloc.sh 4 20 -> select=5
 
 MAX_TRIALS=10
+
+# Resolve the repository from this script's own location, before any cd, so
+# the utilities that ship with it are used rather than an older installed
+# copy. conda.sh prepends the deployed installation to PATH, so the repository
+# has to be prepended after it is sourced.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source /flare/Aurora_deployment/AuroraGPT/soft/checkpoint_restart/conda.sh
+export PATH=$SCRIPT_DIR/utils:$SCRIPT_DIR/job_monitoring:$PATH
 
 IFS='.' read -ra ADDR <<< "$PBS_JOBID"
 export JOBID=$ADDR
@@ -73,9 +80,10 @@ do
         break
     fi
 
-    # Retire the nodes used by this failed trial, plus anything that failed the
-    # health check, so the next trial pulls fresh nodes from the spare pool.
-    cat pbs_nodefile$RUN pbs_nodefile$RUN.unhealthy 2>/dev/null | sort -u > retired_nodes$RUN
+    # Retire only the nodes that failed the health check. Nodes that were
+    # merely in use return to the pool: retiring an entire trial would drain a
+    # 5 node pool after a single 4 node attempt, leaving nothing for a restart.
+    cat pbs_nodefile$RUN.unhealthy 2>/dev/null | sort -u > retired_nodes$RUN
     grep -vxF -f retired_nodes$RUN nodefile_pool > nodefile_pool.next
     mv nodefile_pool.next nodefile_pool
     echo "Spare pool after trial $RUN: $(cat nodefile_pool | wc -l) nodes remain"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ setup(
         "job_monitoring/check_hang.py",
         "job_monitoring/check_nan.py",
         "utils/get_healthy_nodes.sh",
+        "utils/overalloc.sh",
+        "utils/node_usage_summary.sh",
         "system_monitoring/run_health_checks.py",
         "system_monitoring/dashboard.py",
         "utils/launcher.sh",

--- a/test_pyjob.py
+++ b/test_pyjob.py
@@ -85,6 +85,10 @@ for i in range(checkpoint, args.niters):
             fout.flush()
         else:
             fout.write(f"{i} iteration ..., result: ...\n")
+            # Flush every iteration. check_hang.py decides whether the job is
+            # alive from this file's mtime, and a buffered write leaves the
+            # mtime unchanged, so an otherwise healthy job is killed as hung.
+            fout.flush()
 fout.close()    
 if rank==0:
     print(f"Job finished at {datetime.datetime.now()}")

--- a/utils/get_healthy_nodes.sh
+++ b/utils/get_healthy_nodes.sh
@@ -1,37 +1,88 @@
 #!/bin/bash
-mkdir -p /tmp/$USER/pbs/
-export PBS_TMPDIR=/tmp/$USER/pbs
-n=0
+# Usage: get_healthy_nodes.sh NODEFILE NUM_NODES_TO_SELECT NEW_NODEFILE [EXCLUDE_FILE]
+#
+# Selects NUM_NODES_TO_SELECT healthy nodes from NODEFILE into NEW_NODEFILE.
+# Nodes listed in the optional EXCLUDE_FILE are treated as unusable and are
+# never selected (used to retire nodes that crashed a previous run).
+#
+# In addition to NEW_NODEFILE, three list files are written alongside it:
+#   NEW_NODEFILE.healthy    - every node that passed the health check
+#   NEW_NODEFILE.unhealthy  - every node that failed the check or was excluded
+#   NEW_NODEFILE.free       - healthy nodes not selected for this run (spares)
+#
+# Invariant: healthy = selected + free
 
-echo "Build a $3 nodes nodefile from $1, which contains $2 nodes"
-for ip in `cat $1 | uniq`;
+ALL_NODEFILE=$1
+SELECT=$2
+NEW_NODEFILE=$3
+EXCLUDE_FILE=$4
+
+if [[ -z "$ALL_NODEFILE" || -z "$SELECT" || -z "$NEW_NODEFILE" ]]; then
+    echo "Usage: $0 NODEFILE NUM_NODES_TO_SELECT NEW_NODEFILE [EXCLUDE_FILE]"
+    exit 2
+fi
+
+HEALTHY_NODEFILE=$NEW_NODEFILE.healthy
+UNHEALTHY_NODEFILE=$NEW_NODEFILE.unhealthy
+FREE_NODEFILE=$NEW_NODEFILE.free
+
+mkdir -p /tmp/$USER/pbs/
+export PBS_TMPDIR=$(mktemp -d /tmp/$USER/pbs/XXXXXX)
+
+echo "Build a $SELECT nodes nodefile from $ALL_NODEFILE"
+
+n=0
+for ip in `cat $ALL_NODEFILE | uniq`;
 do
    (
+      # A node retired by a previous trial is unusable regardless of ping
+      if [[ -n "$EXCLUDE_FILE" && -f "$EXCLUDE_FILE" ]] && grep -qxF "$ip" "$EXCLUDE_FILE"; then
+	  echo $ip > $PBS_TMPDIR/down.$n
+	  exit 0
+      fi
+
       ping $ip -c2 &> /dev/null ;
 
       if [ $? -eq 0 ];
       then
-	  echo $ip >& $PBS_TMPDIR/node$n.dat
+	  echo $ip > $PBS_TMPDIR/up.$n
       else
-	  rm -f $PBS_TMPDIR/node$n.dat
-	  touch $PBS_TMPDIR/node$n.dat
+	  echo $ip > $PBS_TMPDIR/down.$n
       fi
    )&
    n=$((n+1))
 done
 wait
-rm -rf $3
-if [[ $n -lt $3 ]];then
-    echo "The number of nodes available is smaller than requested; existing..."
+
+rm -f $NEW_NODEFILE $HEALTHY_NODEFILE $UNHEALTHY_NODEFILE $FREE_NODEFILE
+touch $HEALTHY_NODEFILE $UNHEALTHY_NODEFILE $FREE_NODEFILE
+
+# Collect in original nodefile order (numeric index, not glob order)
+for i in `seq 0 $((n-1))`
+do
+    [ -f $PBS_TMPDIR/up.$i ]   && cat $PBS_TMPDIR/up.$i   >> $HEALTHY_NODEFILE
+    [ -f $PBS_TMPDIR/down.$i ] && cat $PBS_TMPDIR/down.$i >> $UNHEALTHY_NODEFILE
+done
+
+NUM_HEALTHY=$(cat $HEALTHY_NODEFILE | wc -l)
+NUM_UNHEALTHY=$(cat $UNHEALTHY_NODEFILE | wc -l)
+
+echo "Total number of nodes checked: $n"
+echo "Number of nodes that are healthy: $NUM_HEALTHY"
+echo "Number of nodes that are unhealthy: $NUM_UNHEALTHY"
+
+if [[ $NUM_HEALTHY -lt $SELECT ]]; then
+    echo "The number of healthy nodes ($NUM_HEALTHY) is smaller than requested ($SELECT); existing..."
+    rm -rf $PBS_TMPDIR
     exit 100
 fi
 
-export SELECT=$2
-echo "Total number of nodes checked: $n"
-for i in `seq 0 $((SELECT-1))`
-do
-    cat $PBS_TMPDIR/node$i.dat >> $3
-done
+# Select the first SELECT healthy nodes; the rest stay free as spares
+head -n $SELECT           $HEALTHY_NODEFILE >  $NEW_NODEFILE
+tail -n +$((SELECT+1))    $HEALTHY_NODEFILE >  $FREE_NODEFILE
 
-echo "Number of nodes that are selected: $(cat $3 | uniq | wc -l)"
-rm -rf /tmp/$USER/pbs/
+echo "Number of nodes that are selected: $(cat $NEW_NODEFILE | uniq | wc -l)"
+echo "Number of healthy nodes still free: $(cat $FREE_NODEFILE | uniq | wc -l)"
+echo "Node lists: $HEALTHY_NODEFILE $UNHEALTHY_NODEFILE $FREE_NODEFILE"
+
+rm -rf $PBS_TMPDIR

--- a/utils/node_usage_summary.sh
+++ b/utils/node_usage_summary.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Print a node-usage summary for a checkpoint/restart run.
+#
+# Usage: node_usage_summary.sh [RUNDIR] [simple|full]
+#        node_usage_summary.sh --full [RUNDIR]
+#
+#   simple (default)  Fixed-size report. Output does not grow with node count,
+#                     so it stays readable for a 1000 node job. Per-node
+#                     detail is aggregated; only crashed nodes are named, and
+#                     that list is capped.
+#   full              Every node and every trial listed individually.
+#
+# Reads node_usage.tsv, the ledger the submission script appends to:
+#   trial <TAB> node <TAB> START|COMPLETED|STOPPED|CRASHED <TAB> timestamp <TAB> epoch
+
+MODE=simple
+ARGS=()
+for a in "$@"; do
+    case "$a" in
+        --full|full)     MODE=full ;;
+        --simple|simple) MODE=simple ;;
+        *)               ARGS+=("$a") ;;
+    esac
+done
+RUNDIR=${ARGS[0]:-$PWD}
+
+# How many crashed nodes to name in simple mode before truncating.
+MAX_LIST=${NODE_SUMMARY_MAX_LIST:-10}
+
+cd "$RUNDIR" 2>/dev/null || { echo "no such directory: $RUNDIR" >&2; exit 1; }
+
+if [ ! -s node_usage.tsv ]; then
+    echo "no node_usage.tsv in $RUNDIR -- nothing to summarise" >&2
+    exit 1
+fi
+
+fmt_dur() {   # seconds -> Hh MMm SSs, omitting empty leading units
+    local s=${1:-0}
+    if   [ "$s" -ge 3600 ]; then printf '%dh %02dm %02ds' $((s/3600)) $((s%3600/60)) $((s%60))
+    elif [ "$s" -ge 60 ];   then printf '%dm %02ds' $((s/60)) $((s%60))
+    else printf '%ds' "$s"; fi
+}
+
+# Print at most MAX_LIST names, then a count of the remainder.
+print_capped() {
+    local n=0 total
+    total=$(grep -c . <<< "$1")
+    [ -z "$1" ] && return
+    while read -r name; do
+        [ -z "$name" ] && continue
+        n=$((n+1))
+        if [ "$n" -gt "$MAX_LIST" ]; then
+            echo "    ... and $((total - MAX_LIST)) more (use 'full' to list all)"
+            return
+        fi
+        echo "    $name"
+    done <<< "$1"
+}
+
+TOTAL_ALLOC=$(wc -l < nodefile_all 2>/dev/null || echo 0)
+TRIAL_IDS=$(awk -F'\t' '$3=="START"{print $1}' node_usage.tsv | sort -un)
+TRIALS=$(grep -c . <<< "$TRIAL_IDS")
+
+RUN_START=$(head -1 node_usage.tsv | cut -f4)
+RUN_START_E=$(head -1 node_usage.tsv | cut -f5)
+RUN_END=$(tail -1 node_usage.tsv | cut -f4)
+RUN_END_E=$(tail -1 node_usage.tsv | cut -f5)
+
+USED=$(awk -F'\t' '$3=="START"{print $2}' node_usage.tsv | sort -u)
+NUSED=$(grep -c . <<< "$USED")
+CRASHED=$(awk -F'\t' '$3=="CRASHED"{print $2}' node_usage.tsv | sort -u)
+NCRASH=$(grep -c . <<< "$CRASHED")
+[ -z "$CRASHED" ] && NCRASH=0
+
+FIRST_TRIAL=$(head -1 <<< "$TRIAL_IDS")
+N_FIRST=$(awk -F'\t' -v t="$FIRST_TRIAL" '$1==t && $3=="START"' node_usage.tsv | wc -l)
+SPARES_SPENT=$((NUSED - N_FIRST))
+
+# Total node-seconds across all trials, and the per-node aggregate table.
+NODE_TOTALS=$(awk -F'\t' '
+    $3=="START" { start[$1 SUBSEP $2]=$5; trials[$2]++; next }
+                { k=$1 SUBSEP $2
+                  if (k in start) { total[$2] += $5 - start[k]; delete start[k] }
+                  if ($3=="CRASHED") outcome[$2]="CRASHED"
+                  else if (outcome[$2]!="CRASHED") outcome[$2]=$3 }
+    END { for (n in trials) printf "%s\t%d\t%d\t%s\n", n, trials[n], total[n], outcome[n] }
+' node_usage.tsv | sort)
+
+NODE_SECONDS=$(awk -F'\t' '{s+=$3} END {print s+0}' <<< "$NODE_TOTALS")
+
+echo "=========================================================="
+echo " NODE USAGE SUMMARY ($MODE)"
+echo "=========================================================="
+echo "Run directory : $RUNDIR"
+echo "Window        : $RUN_START -> $RUN_END  ($(fmt_dur $((RUN_END_E - RUN_START_E))))"
+echo "Allocated     : $TOTAL_ALLOC nodes"
+echo "Trials run    : $TRIALS"
+echo "Nodes used    : $NUSED of $TOTAL_ALLOC"
+echo "Node-time     : $(fmt_dur $NODE_SECONDS) total across all nodes and trials"
+echo
+
+if [ "$MODE" == "full" ]; then
+    echo "--- Per trial ---"
+    for T in $TRIAL_IDS; do
+        T_START=$(awk -F'\t' -v t="$T" '$1==t && $3=="START"{print $4; exit}' node_usage.tsv)
+        T_START_E=$(awk -F'\t' -v t="$T" '$1==t && $3=="START"{print $5; exit}' node_usage.tsv)
+        T_END=$(awk -F'\t' -v t="$T" '$1==t && $3!="START"{print $4; exit}' node_usage.tsv)
+        T_END_E=$(awk -F'\t' -v t="$T" '$1==t && $3!="START"{print $5; exit}' node_usage.tsv)
+        NNODES=$(awk -F'\t' -v t="$T" '$1==t && $3=="START"' node_usage.tsv | wc -l)
+        if [ -n "$T_END_E" ]; then DUR=$(fmt_dur $((T_END_E - T_START_E)))
+        else DUR="(did not finish)"; T_END="-"; fi
+        echo "Trial $T: $NNODES nodes   $T_START -> ${T_END}   held $DUR"
+        awk -F'\t' -v t="$T" '$1==t && $3=="START"{printf "    %s  %s\n", $4, $2}' node_usage.tsv
+        awk -F'\t' -v t="$T" '$1==t && $3=="CRASHED"{printf "    %s  %s  <-- CRASHED\n", $4, $2}' node_usage.tsv
+        echo
+    done
+
+    echo "--- Per node (total time in service) ---"
+    printf "%-46s %7s %9s  %s\n" "NODE" "TRIALS" "HELD" "OUTCOME"
+    while IFS=$'\t' read -r NODE NT SECS OUT; do
+        [ -z "$NODE" ] && continue
+        printf "%-46s %7s %9s  %s\n" "$NODE" "$NT" "$(fmt_dur ${SECS:-0})" "${OUT:-UNKNOWN}"
+    done <<< "$NODE_TOTALS"
+    echo
+else
+    # Simple mode: one line per trial, and counts instead of node lists.
+    echo "--- Per trial ---"
+    printf "%-7s %7s  %-19s %-19s %s\n" "TRIAL" "NODES" "START" "END" "HELD"
+    for T in $TRIAL_IDS; do
+        T_START=$(awk -F'\t' -v t="$T" '$1==t && $3=="START"{print $4; exit}' node_usage.tsv)
+        T_START_E=$(awk -F'\t' -v t="$T" '$1==t && $3=="START"{print $5; exit}' node_usage.tsv)
+        T_END=$(awk -F'\t' -v t="$T" '$1==t && $3!="START"{print $4; exit}' node_usage.tsv)
+        T_END_E=$(awk -F'\t' -v t="$T" '$1==t && $3!="START"{print $5; exit}' node_usage.tsv)
+        NNODES=$(awk -F'\t' -v t="$T" '$1==t && $3=="START"' node_usage.tsv | wc -l)
+        NCR=$(awk -F'\t' -v t="$T" '$1==t && $3=="CRASHED"' node_usage.tsv | wc -l)
+        if [ -n "$T_END_E" ]; then DUR=$(fmt_dur $((T_END_E - T_START_E)))
+        else DUR="(running)"; T_END="-"; fi
+        NOTE=""
+        [ "$NCR" -gt 0 ] && NOTE="  ($NCR crashed)"
+        printf "%-7s %7s  %-19s %-19s %s%s\n" "$T" "$NNODES" "$T_START" "$T_END" "$DUR" "$NOTE"
+    done
+    echo
+
+    # Outcome histogram rather than one row per node.
+    echo "--- Node outcomes ---"
+    awk -F'\t' '{c[$4]++} END {for (o in c) printf "    %-12s %d\n", o, c[o]}' <<< "$NODE_TOTALS" | sort -k2 -rn
+    echo
+fi
+
+echo "--- Spare capacity ---"
+echo "Nodes that ran work : $NUSED of $TOTAL_ALLOC allocated"
+NEVER=""
+if [ -s nodefile_all ]; then
+    NEVER=$(grep -vxF -f <(echo "$USED") nodefile_all 2>/dev/null)
+fi
+NNEVER=$(grep -c . <<< "$NEVER")
+[ -z "$NEVER" ] && NNEVER=0
+echo "Nodes lost to crash : $NCRASH"
+[ "$SPARES_SPENT" -gt 0 ] && \
+    echo "Spares drawn in     : $SPARES_SPENT (beyond the $N_FIRST that started trial $FIRST_TRIAL)"
+echo "Unspent reserve     : $NNEVER"
+
+if [ "$NCRASH" -gt 0 ]; then
+    echo "Crashed nodes:"
+    if [ "$MODE" == "full" ]; then echo "$CRASHED" | sed 's/^/    /'
+    else print_capped "$CRASHED"; fi
+fi
+if [ "$NNEVER" -gt 0 ] && [ "$MODE" == "full" ]; then
+    echo "Never used (unspent reserve):"
+    echo "$NEVER" | sed 's/^/    /'
+fi
+echo "=========================================================="
+[ "$MODE" == "simple" ] && echo "(node_usage_summary.sh $RUNDIR full  for the per-node breakdown)"

--- a/utils/overalloc.sh
+++ b/utils/overalloc.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Usage: overalloc.sh JOBSIZE RESERVE_PERCENT
+#
+# Prints the number of nodes to request from PBS so that JOBSIZE nodes can run
+# while keeping RESERVE_PERCENT extra nodes as a spare pool for restarts.
+#
+#   total = JOBSIZE + ceil(JOBSIZE * RESERVE_PERCENT / 100)
+#
+# A non-zero RESERVE_PERCENT always yields at least one spare node.
+#
+# Example:
+#   overalloc.sh 10 20   -> 12
+#   #PBS -l select=$(overalloc.sh 10 20)
+
+JOBSIZE=$1
+PERCENT=$2
+
+if [[ -z "$JOBSIZE" || -z "$PERCENT" ]]; then
+    echo "Usage: $0 JOBSIZE RESERVE_PERCENT" >&2
+    exit 2
+fi
+
+if ! [[ "$JOBSIZE" =~ ^[0-9]+$ ]] || [ "$JOBSIZE" -lt 1 ]; then
+    echo "JOBSIZE must be a positive integer, got '$JOBSIZE'" >&2
+    exit 2
+fi
+
+if ! [[ "$PERCENT" =~ ^[0-9]+$ ]]; then
+    echo "RESERVE_PERCENT must be a non-negative integer, got '$PERCENT'" >&2
+    exit 2
+fi
+
+# Integer ceiling division
+SPARE=$(( (JOBSIZE * PERCENT + 99) / 100 ))
+
+# Any non-zero reserve should give at least one spare node
+if [ "$PERCENT" -gt 0 ] && [ "$SPARE" -lt 1 ]; then
+    SPARE=1
+fi
+
+echo $((JOBSIZE + SPARE))


### PR DESCRIPTION
## Summary

A multi-node job loses its entire allocation when a single node fails: PBS terminates the job and all uncheckpointed work is discarded. This change lets a job request a reserve of spare nodes, detect the failed node, and resume from the last checkpoint on a substitute node without leaving the queue.

The scope is node substitution *within* an existing allocation. Requesting the reserve remains the responsibility of the user.

**Base:** `e056ebf` &nbsp;•&nbsp; **Platform:** Aurora (ALCF) &nbsp;•&nbsp; **Verified:** jobs 8747717, 8747771, 8747844, 8747861

---

## Changes

| File | +/- |
|------|-----|
| `README.md` | +127 −1 |
| `qsub_multi_mpiexec.sc` | +45 −6 |
| `utils/get_healthy_nodes.sh` | +69 −18 |
| `setup.py` | +2 |
| `utils/overalloc.sh` *(new)* | +41 |
| `utils/node_usage_summary.sh` *(new)* | +173 |
| `examples/crash_restart/qsub.sc` *(new)* | +211 |
| `examples/crash_restart/crash_node.sh` *(new)* | +32 |
| `examples/crash_restart/README.md` *(new)* | +419 |

9 files changed, 1119 insertions(+), 25 deletions(−)

---

## Features

### 1. Node classification — `utils/get_healthy_nodes.sh`

Previously the script emitted only the selected nodefile. It now writes three additional lists alongside it, making the disposition of every allocated node explicit:

| List | Contents |
|------|----------|
| `<nodefile>.healthy` | passed the health check |
| `<nodefile>.unhealthy` | failed the check, or named in the exclude file |
| `<nodefile>.free` | healthy but unselected — the remaining reserve |

Invariant: `healthy = selected + free`.

A fourth positional argument, `EXCLUDE_FILE`, was added. Nodes listed in it are classified unhealthy **without being probed**, so a node that has already failed is never reselected even when it remains reachable. This matters for failures that do not take the node off the network.

```bash
get_healthy_nodes.sh nodefile_pool JOBSIZE pbs_nodefile1 crashed_nodes
```

Exit status `100` indicates fewer healthy nodes than requested.

### 2. Reserve sizing — `utils/overalloc.sh` (new)

Computes the node count to request for a given job size and reserve percentage:

```
total = JOBSIZE + ceil(JOBSIZE * RESERVE_PERCENT / 100)
```

```console
$ overalloc.sh 4 50
6
$ overalloc.sh 512 20
615
$ overalloc.sh 10 0
10
```

Any non-zero percentage reserves at least one whole node, so small jobs are not rounded down to a reserve of zero.

> **This is a calculator, not an allocator.** PBS fixes the node count from the `#PBS -l select=` directive before the job script begins executing, so no code in the package can enlarge its own allocation. The user runs `overalloc.sh` before submission and writes the result into the directive. The package then manages spares within the allocation it is given.

Because `select=`, `JOBSIZE` and `RESERVE_PERCENT` are declared independently, both submission scripts now recompute the requirement at runtime and abort when the allocation is short:

```
FAIL: allocation of 4 nodes is smaller than the 5 required
      for JOBSIZE=4 with a 20% reserve.
      Set '#PBS -l select=5' or lower JOBSIZE/RESERVE_PERCENT.
```

Without this check a mismatch is silent until a node is lost and no spare exists.

### 3. Failed-node retirement — `qsub_multi_mpiexec.sc`

The retirement logic previously removed *every* node used by a failed trial. With a 6-node allocation and a 4-node job, one failure would drop the pool to 2 and the next trial could not start. Only the nodes that actually failed are now retired; the remainder return to the pool.

Selection always draws from the full pool less retired nodes, rather than from the previous trial's subset, so the candidate pool does not contract on each iteration.

### 4. Node-usage accounting — `utils/node_usage_summary.sh` (new)

Each trial appends one row per node per event to `node_usage.tsv`:

```
trial <TAB> node <TAB> START|COMPLETED|STOPPED|CRASHED <TAB> timestamp <TAB> epoch
```

From this ledger the summary reports which nodes ran, when each entered and left service, how long each was held, which failed, and how much of the reserve was consumed. It runs automatically at the end of a job and can be re-run against any completed run directory.

Two verbosity levels are provided, because the per-node table does not scale:

```bash
node_usage_summary.sh <rundir> simple    # fixed size, ~30 lines
node_usage_summary.sh <rundir> full      # one line per node per trial
```

| Run | `simple` | `full` |
|-----|---------:|-------:|
| 6 nodes, 2 trials *(measured)* | 28 | 42 |
| 1000 nodes, 3 trials *(synthetic)* | 31 | 3434 |

Simple mode is `O(trials)`, not `O(nodes)`. Counts remain exact at all scales; only *name lists* are truncated, at 10 by default, adjustable with `NODE_SUMMARY_MAX_LIST`. The submission script prints simple mode to the console and writes full mode to `node_usage_full.log`, so no detail is lost.

### 5. Worked example — `examples/crash_restart/`

| File | Purpose |
|------|---------|
| `qsub.sc` | 6-node allocation, 4-node job, one node failed on purpose |
| `crash_node.sh` | fault injector, test use only |
| `README.md` | converting an ordinary job script into a tolerant one |

The README documents the five required modifications, contrasts the behaviour with and without the package, and records the failure modes encountered during development.

`crash_node.sh` wraps the target command and exits non-zero on one designated host, recording that host in `$CRASHED_NODES_FILE` under `flock`. On every other host it `exec`s the command unchanged. It is deliberately placed in `examples/` rather than `utils/` and is **not** installed onto `$PATH`: a tool whose function is to terminate running applications should not be readily invocable in production.

### 6. Run directory layout

A run writes its own artifacts into one self-contained directory, so that concurrent or successive runs cannot overwrite one another and a run can be inspected in full after the fact:

```
<rundir>/
  run.log                    combined log for the whole job
  nodefile_all               the full PBS allocation
  nodefile_pool              candidate nodes, shrinks as nodes are retired
  crashed_nodes              nodes that died, excluded from later trials
  pbs_nodefile<N>            nodes used by trial N
  pbs_nodefile<N>.healthy    health lists for trial N
  pbs_nodefile<N>.unhealthy
  pbs_nodefile<N>.free
  retired_nodes<N>           cumulative retired set after trial N
  node_usage.tsv             per-node ledger, one row per node per event
  node_usage_full.log        full per-node usage summary
  latest                     checkpoint (iteration number)
  output.log                 job output
  check_hang.log             hang-detector log
```

The location depends on the submission script:

| Script | Run directory |
|--------|---------------|
| `qsub_multi_mpiexec.sc` | `$PBS_O_WORKDIR`, the submission directory |
| `examples/crash_restart/qsub.sc` | `tests/03-multi-node/results/batch-<jobid>` |

The example writes outside the repository, overridable with `TEST_ROOT`, so that a test run leaves no artifacts in the tree under test. This was changed during development: the script previously wrote to `runs/<jobid>/` inside the repository, which polluted the working tree on every run.

`get_healthy_nodes.sh` and `flush.sh` continue to use `/tmp/$USER/pbs/` for node-local scratch. Only the run's own artifacts are written to the run directory.

---

## Sample output

<details>
<summary>Console output from a passing run — job 8747844, <code>JOBSIZE=4</code>, <code>RESERVE_PERCENT=50</code></summary>

```
==========================================================
Run dir   : .../tests/03-multi-node/results/batch-8747844
Allocated : 6 nodes
JOBSIZE   : 4  (+50% reserve -> needs 6)
Nodes     : x4302c6s1b0n0 x4302c6s2b0n0 x4302c6s3b0n0 x4302c6s4b0n0
            x4302c6s5b0n0 x4302c6s6b0n0
==========================================================
Will inject a crash on x4302c6s2b0n0 during trial 1

---------- TRIAL 1 ----------
Build a 4 nodes nodefile from nodefile_pool
Total number of nodes checked: 6
Number of nodes that are healthy: 6
Number of nodes that are unhealthy: 0
Number of nodes that are selected: 4
Number of healthy nodes still free: 2
Node lists: pbs_nodefile1.healthy pbs_nodefile1.unhealthy pbs_nodefile1.free
trial 1 started at 2026-08-11 03:17:22
running on:
    [2026-08-11 03:17:22] x4302c6s1b0n0.hsn.cm.aurora.alcf.anl.gov
    [2026-08-11 03:17:22] x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov
    [2026-08-11 03:17:22] x4302c6s3b0n0.hsn.cm.aurora.alcf.anl.gov
    [2026-08-11 03:17:22] x4302c6s4b0n0.hsn.cm.aurora.alcf.anl.gov
free pool : x4302c6s5b0n0.hsn.cm.aurora.alcf.anl.gov x4302c6s6b0n0.hsn...
CRASH-INJECT: simulating node failure on x4302c6s2b0n0 (trial 1)
x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov: rank 21 exited with code 42
x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov: rank 12 died from signal 15
trial 1 ended at 2026-08-11 03:17:35 (exit 143)
Job exited with 143, will rerun
retired so far: x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov
checkpoint at : 12

---------- TRIAL 2 ----------
Build a 4 nodes nodefile from nodefile_pool
Total number of nodes checked: 6
Number of nodes that are healthy: 5
Number of nodes that are unhealthy: 1
Number of nodes that are selected: 4
Number of healthy nodes still free: 1
trial 2 started at 2026-08-11 03:17:43
running on:
    [2026-08-11 03:17:43] x4302c6s1b0n0.hsn.cm.aurora.alcf.anl.gov
    [2026-08-11 03:17:43] x4302c6s3b0n0.hsn.cm.aurora.alcf.anl.gov
    [2026-08-11 03:17:43] x4302c6s4b0n0.hsn.cm.aurora.alcf.anl.gov
    [2026-08-11 03:17:43] x4302c6s5b0n0.hsn.cm.aurora.alcf.anl.gov
free pool : x4302c6s6b0n0.hsn.cm.aurora.alcf.anl.gov
Reading checkpoint from 12
12 iteration ...
   ...
29 iteration ...
trial 2 ended at 2026-08-11 03:18:02 (exit 0)
Job run successfully on trial 2

RESULT: SUCCESS after 2 trial(s)
==========================================================
Trials used     : 2
Crashed nodes   : x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov
Final checkpoint: 29
Output lines    : 18
```
</details>

<details>
<summary>Node usage summary — <code>simple</code> mode, printed automatically at the end of a job</summary>

```
==========================================================
 NODE USAGE SUMMARY (simple)
==========================================================
Run directory : .../tests/03-multi-node/results/batch-8747844
Window        : 2026-08-11 03:17:22 -> 2026-08-11 03:18:02  (40s)
Allocated     : 6 nodes
Trials run    : 2
Nodes used    : 5 of 6
Node-time     : 2m 08s total across all nodes and trials

--- Per trial ---
TRIAL     NODES  START               END                 HELD
1             4  2026-08-11 03:17:22 2026-08-11 03:17:35 13s  (1 crashed)
2             4  2026-08-11 03:17:43 2026-08-11 03:18:02 19s

--- Node outcomes ---
    COMPLETED    4
    CRASHED      1

--- Spare capacity ---
Nodes that ran work : 5 of 6 allocated
Nodes lost to crash : 1
Spares drawn in     : 1 (beyond the 4 that started trial 1)
Unspent reserve     : 1
Crashed nodes:
    x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov
==========================================================
```
</details>

<details>
<summary>Same run — <code>full</code> mode, written to <code>node_usage_full.log</code></summary>

```
--- Per trial ---
Trial 1: 4 nodes   2026-08-11 03:17:22 -> 2026-08-11 03:17:35   held 13s
    2026-08-11 03:17:22  x4302c6s1b0n0.hsn.cm.aurora.alcf.anl.gov
    2026-08-11 03:17:22  x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov
    2026-08-11 03:17:22  x4302c6s3b0n0.hsn.cm.aurora.alcf.anl.gov
    2026-08-11 03:17:22  x4302c6s4b0n0.hsn.cm.aurora.alcf.anl.gov
    2026-08-11 03:17:35  x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov  <-- CRASHED

Trial 2: 4 nodes   2026-08-11 03:17:43 -> 2026-08-11 03:18:02   held 19s
    ...

--- Per node (total time in service) ---
NODE                                            TRIALS      HELD  OUTCOME
x4302c6s1b0n0.hsn.cm.aurora.alcf.anl.gov             2       32s  COMPLETED
x4302c6s2b0n0.hsn.cm.aurora.alcf.anl.gov             1       13s  CRASHED
x4302c6s3b0n0.hsn.cm.aurora.alcf.anl.gov             2       32s  COMPLETED
x4302c6s4b0n0.hsn.cm.aurora.alcf.anl.gov             2       32s  COMPLETED
x4302c6s5b0n0.hsn.cm.aurora.alcf.anl.gov             1       19s  COMPLETED

Never used (unspent reserve):
    x4302c6s6b0n0.hsn.cm.aurora.alcf.anl.gov
```
</details>

---

## Verification

Tests are held in a separate tree (`checkmate-test/tests/`) so that no artifact is written into the repository under test.

| Test | Scale | Assertion | Result |
|------|-------|-----------|:------:|
| 02-01 | 1 node | `launcher` → `crash_node.sh` → payload chain runs | **PASS** |
| 02-02 | 1 node | fault fires on the target host, exit propagates | **PASS** |
| 02-03 | 1 node | payload resumes from a checkpoint (10 → 29) | **PASS** |
| 03-01 | 6 nodes | fail a node, restart on a spare, complete | **PASS** |

The end-to-end result was also produced by `examples/crash_restart/qsub.sc` itself rather than only by the harness, on jobs 8747717, 8747771, 8747844 and 8747861. Job 8747861 was run from `examples/crash_restart/` after the reorganisation, confirming that path resolution, the relocated fault injector and the four repointed test scripts all work from the new location.

**Evidence chain for 03-01:**

| Stage | Observed |
|-------|----------|
| Allocation | 6 nodes for `JOBSIZE` 4 + 50% |
| Trial 1 selection | 4 nodes, 2 free |
| Fault | `x4302c6s2b0n0` recorded in `crashed_nodes` |
| Trial 1 exit | 143, checkpoint at 12 |
| Trial 2 exclusion | failed node present in `pbs_nodefile2.unhealthy` |
| Trial 2 selection | 4 nodes, spare drawn in, 1 free remaining |
| Resume | execution restarts at iteration 12 |
| Completion | checkpoint 29, exit 0, 2 trials |

The free pool contracting from `[c2s5, c2s6]` to `[c2s6]` is the reserve being spent as designed: one spare consumed, one retained.

**Evidence chain for the post-reorganisation run — job 8747861:**

| Stage | Observed |
|-------|----------|
| Trial 1 nodes | `x4216c7s0b0n0` `x4210c2s3b0n0` `x4300c2s4b0n0` `x4310c1s0b0n0` |
| Fault | `x4210c2s3b0n0` recorded in `crashed_nodes` |
| Trial 2 exclusion | same node present in `pbs_nodefile2.unhealthy` |
| Trial 2 nodes | `x4216c7s0b0n0` `x4300c2s4b0n0` `x4310c1s0b0n0` `x4618c1s3b0n0` |
| Substitution | `x4618c1s3b0n0` drawn from the reserve |
| Resume | `Reading checkpoint from 11` |
| Completion | checkpoint 29, `RESULT: SUCCESS after 2 trial(s)` |

> **Not yet verified:** the runtime guard added to `qsub_multi_mpiexec.sc` was checked as extracted logic on Aurora, using the real `overalloc.sh` across five allocation/`JOBSIZE`/percentage combinations, but has not been exercised inside a live job. That script is the upstream example and was not otherwise re-run.

---

## Defects found and fixed during development

**Hostname domain mismatch.** Aurora presents three forms of a node name: `hostname` returns the short form (`x4302c6s2b0n0`), `$PBS_NODEFILE` contains `.hsn.cm.aurora.alcf.anl.gov`, and `hostname -f` returns `.hostmgmt.cm.aurora.alcf.anl.gov`. Comparing the wrong pair fails silently: the fault injector never matched its target and the job ran to completion with no fault injected, which presents as a pass. Comparison is now on the short form, while the nodefile spelling is what gets recorded.

**Missing Python environment.** Without sourcing `conda.sh`, `python` is absent on the compute nodes and every rank exits 127. The retry loop treated this as a node fault and burned through all trials in 38 seconds, reporting a plausible-looking failure. A guard now aborts when no trial makes progress.

**Over-broad retirement.** Retiring all nodes of a failed trial exhausted the reserve after a single fault. Corrected as described above.

**Missing `--no-vni`.** The submission script omitted the flag that the working tests required.

**Summary state precedence.** In the per-node table the first recorded outcome won, so nodes that completed in a later trial were reported as `STOPPED`. The most recent outcome now wins, except that a crash is terminal for that node.

---

## Notes for reviewers

`utils/flush.sh` emits `line 2: UID: readonly variable` on every trial. This is pre-existing and out of scope; it was left untouched deliberately.

`examples/hang/qsub.sc` contains a typo, `mpiexe`. Also pre-existing and not addressed here.

The `.unhealthy` list conflates two distinct conditions: *failed the health probe*, and *excluded by the caller*. Both are unusable for the current job so the distinction does not affect behaviour, but a future change wanting to retry transiently unreachable nodes would need to separate them.

**A zero exit status does not indicate success.** A retry loop that exhausts every trial still exits 0, and `qstat -x` reports terminated jobs with `state=F` exactly as it does for jobs that completed normally. Review the run log rather than the exit status.
